### PR TITLE
fix: updated type compatibility check to verify CommandUser assignment

### DIFF
--- a/common/src/main/java/net/william278/uniform/CommandExecutor.java
+++ b/common/src/main/java/net/william278/uniform/CommandExecutor.java
@@ -58,7 +58,7 @@ public interface CommandExecutor<S> {
                 params[i] = context.getArgument(arg.name(), type);
                 continue;
             }
-            if (type.isAssignableFrom(CommandUser.class)) {
+            if (CommandUser.class.isAssignableFrom(type)) {
                 params[i] = cmd.getUser(context.getSource());
                 continue;
             }


### PR DESCRIPTION
This pull request includes a minor change to the `CommandExecutor` class. The change corrects the logic for checking if a type is assignable from `CommandUser`.

* [`common/src/main/java/net/william278/uniform/CommandExecutor.java`](diffhunk://#diff-bee945dcba1e336921a77832d1c1f56e415c3e7d761419c356f85053c9f01ea4L61-R61): Modified the condition to use `CommandUser.class.isAssignableFrom(type)` instead of `type.isAssignableFrom(CommandUser.class)` to properly check type assignability.

Issue: https://github.com/WiIIiam278/Uniform/issues/45