### PR TITLE
fix: shutdown cached executor in ServerLifecycleEvents.SERVER_STOPPED

### DIFF
--- a/common/src/main/java/net/william278/uniform/BaseCommand.java
+++ b/common/src/main/java/net/william278/uniform/BaseCommand.java
@@ -25,6 +25,8 @@ import com.mojang.brigadier.arguments.*;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import lombok.Getter;
 import net.william278.uniform.element.ArgumentElement;
 import net.william278.uniform.element.CommandElement;
@@ -39,6 +41,8 @@ import java.util.function.Predicate;
 @Getter
 @SuppressWarnings("unused")
 public abstract class BaseCommand<S> {
+
+    protected static final ExecutorService CACHED_EXECUTOR = Executors.newCachedThreadPool();
 
     private final String name;
     private final String description;

--- a/common/src/main/java/net/william278/uniform/Execution.java
+++ b/common/src/main/java/net/william278/uniform/Execution.java
@@ -25,14 +25,10 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.function.Predicate;
 
 record Execution<S>(@NotNull Predicate<S> predicate, @Nullable CommandExecutor<S> defaultExecutor,
                     @Nullable CommandExecutor<S> executor, @Nullable Predicate<S> condition) implements Predicate<S> {
-
-    private static final Executor CACHED_EXECUTOR = Executors.newCachedThreadPool();
 
     @NotNull
     static <S> Execution<S> fromCommand(@NotNull BaseCommand<S> command) {
@@ -75,7 +71,7 @@ record Execution<S>(@NotNull Predicate<S> predicate, @Nullable CommandExecutor<S
     @NotNull
     private static <S> com.mojang.brigadier.Command<S> convertExecutor(@NotNull CommandExecutor<S> executor) {
         return context -> {
-            CACHED_EXECUTOR.execute(() -> executor.execute(context));
+            BaseCommand.CACHED_EXECUTOR.execute(() -> executor.execute(context));
             return 1;
         };
     }

--- a/common/src/main/java/net/william278/uniform/Uniform.java
+++ b/common/src/main/java/net/william278/uniform/Uniform.java
@@ -44,4 +44,8 @@ public interface Uniform {
 
     void setCommandUserSupplier(@NotNull Function<Object, CommandUser> supplier);
 
+    default void shutdown() {
+        BaseCommand.CACHED_EXECUTOR.shutdownNow();
+    }
+
 }

--- a/fabric-1.20.1/src/main/java/net/william278/uniform/fabric/FabricUniform.java
+++ b/fabric-1.20.1/src/main/java/net/william278/uniform/fabric/FabricUniform.java
@@ -26,6 +26,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import lombok.Getter;
 import lombok.Setter;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.server.command.ServerCommandSource;
 import net.william278.uniform.BaseCommand;
 import net.william278.uniform.Command;
@@ -73,6 +74,8 @@ public final class FabricUniform implements Uniform {
                     ));
                 })
         );
+
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> shutdown());
     }
 
     /**

--- a/fabric-1.21.1/src/main/java/net/william278/uniform/fabric/FabricUniform.java
+++ b/fabric-1.21.1/src/main/java/net/william278/uniform/fabric/FabricUniform.java
@@ -26,6 +26,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import lombok.Getter;
 import lombok.Setter;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.server.command.ServerCommandSource;
 import net.william278.uniform.BaseCommand;
 import net.william278.uniform.Command;
@@ -73,6 +74,8 @@ public final class FabricUniform implements Uniform {
                     ));
                 })
         );
+
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> shutdown());
     }
 
     /**

--- a/fabric-1.21.4/src/main/java/net/william278/uniform/fabric/FabricUniform.java
+++ b/fabric-1.21.4/src/main/java/net/william278/uniform/fabric/FabricUniform.java
@@ -26,6 +26,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import lombok.Getter;
 import lombok.Setter;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.server.command.ServerCommandSource;
 import net.william278.uniform.BaseCommand;
 import net.william278.uniform.Command;
@@ -73,6 +74,8 @@ public final class FabricUniform implements Uniform {
                     ));
                 })
         );
+
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> shutdown());
     }
 
     /**


### PR DESCRIPTION
If `CACHED_EXECUTOR` is not stopped, it causes the server to wait for around 60 seconds (the default value set during the initialization of this Executor) when executing commands like /stop or any similar server-stopping commands. This behavior occurs only after using any command implemented with this library.