### PR TITLE
Fixed mixins for fabric versions 1.21.1, 1.21.4, and 1.21.5

### DIFF
--- a/fabric/1.21.1/src/main/resources/uniform.mixins.json
+++ b/fabric/1.21.1/src/main/resources/uniform.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "net.william278.uniform.fabric.mixins",
+  "compatibilityLevel": "JAVA_17",
+  "server": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/fabric/1.21.4/src/main/resources/uniform.mixins.json
+++ b/fabric/1.21.4/src/main/resources/uniform.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "net.william278.uniform.fabric.mixins",
+  "compatibilityLevel": "JAVA_17",
+  "server": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/fabric/1.21.5/src/main/resources/uniform.mixins.json
+++ b/fabric/1.21.5/src/main/resources/uniform.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "net.william278.uniform.fabric.mixins",
+  "compatibilityLevel": "JAVA_17",
+  "server": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
Fixes issue #135. Overwrites the `uniform.mixins.json` files for Fabric versions 1.21.1, 1.21.4, and 1.21.5 to remove reference to the `CommandManagerMixin`, which appears to be only intended for version 1.21.8