### PR TITLE
Fixed ArgumentNodeMixin missing on versions <=1.21.5

### DIFF
--- a/bungee/build.gradle
+++ b/bungee/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     api project(path: ':common')
 
-    compileOnly 'net.md-5:bungeecord-api:1.17-R0.1-SNAPSHOT'
+    compileOnly 'net.md-5:bungeecord-api:1.21-R0.4-SNAPSHOT'
     compileOnly 'net.kyori:adventure-platform-bungeecord:4.4.1'
     compileOnly 'org.projectlombok:lombok:1.18.36'
 

--- a/fabric/1.21.1/src/main/resources/uniform.mixins.json
+++ b/fabric/1.21.1/src/main/resources/uniform.mixins.json
@@ -4,6 +4,7 @@
   "package": "net.william278.uniform.fabric.mixins",
   "compatibilityLevel": "JAVA_17",
   "server": [
+    "ArgumentNodeMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric/1.21.4/src/main/resources/uniform.mixins.json
+++ b/fabric/1.21.4/src/main/resources/uniform.mixins.json
@@ -4,6 +4,7 @@
   "package": "net.william278.uniform.fabric.mixins",
   "compatibilityLevel": "JAVA_17",
   "server": [
+    "ArgumentNodeMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric/1.21.5/src/main/resources/uniform.mixins.json
+++ b/fabric/1.21.5/src/main/resources/uniform.mixins.json
@@ -4,6 +4,7 @@
   "package": "net.william278.uniform.fabric.mixins",
   "compatibilityLevel": "JAVA_17",
   "server": [
+    "ArgumentNodeMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric/src/main/java/net/william278/uniform/fabric/mixins/ArgumentNodeMixin.java
+++ b/fabric/src/main/java/net/william278/uniform/fabric/mixins/ArgumentNodeMixin.java
@@ -19,7 +19,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-//#if MC>=12108
+//#if MC<=12105
 //$$
 //$$    package net.william278.uniform.fabric.mixins;
 //$$


### PR DESCRIPTION
Fixed [this](https://github.com/WiIIiam278/HuskSync/issues/621) error present on HuskSync by re-implementing the ArgumentNodeMixin on versions 1.21.5 and below that was changed in a previous commit